### PR TITLE
Toolspain specifier for cargo

### DIFF
--- a/cargo/cargo.py
+++ b/cargo/cargo.py
@@ -44,7 +44,14 @@ class Cargo(dotbot.Plugin):
         return False
 
     def _run_cargo_command(self, binary, args, devnull):
-        cmd = ' '.join('cargo install --force {} {}'.format(args, binary).split())
+        if len(args)>0 and args[0]=="+":
+            try:
+                toolchain,args=args.split(" ",1)
+            except ValueError:
+                toolchain,args=args,""
+        else:
+            toolchain=""
+        cmd = ' '.join('cargo {} install --force {} {}'.format(toolchain,args, binary).split())
         self._log.info('Installing Rust binary: {} [{}]'.format(binary, cmd))
         result = subprocess.run(cmd, shell=True, stdin=devnull, stdout=devnull, stderr=subprocess.PIPE, cwd=self._context.base_directory())
         return self._check_cargo_command_output(binary, result)

--- a/cargo/item_handlers/dict_item_handler.py
+++ b/cargo/item_handlers/dict_item_handler.py
@@ -13,7 +13,10 @@ class DictItemHandler(ItemHandler):
             return _error()
         for arg in item[binary]:
             if isinstance(arg, str):
-                args += ' --{}'.format(arg)
+                if arg[0]=="+":
+                    args="{} {}".format(arg,args).strip()
+                else:
+                    args += ' --{}'.format(arg)
             elif isinstance(arg, dict):
                 if len(item) != 1:
                     return _error()


### PR DESCRIPTION

If in dictionary mode an argument starts with a + it is assumed to be a toolchain specifier and shuffled to the front

So with
```
- cargo:
    -
      racer:
        - +nightly
    - rustfmt
    - rls
```
`racer` is installed using the `nightly` toolchain. All others with whatever is the default